### PR TITLE
Add comprehensive unit and integration tests for improved coverage

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     testImplementation("com.google.truth:truth:1.4.4")
     testImplementation(kotlin("test"))
     testImplementation(gradleTestKit())
+    testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.0")
 }
 
 tasks.test {

--- a/core/src/test/kotlin/com/adrianczuczka/structural/StructuralPluginTest.kt
+++ b/core/src/test/kotlin/com/adrianczuczka/structural/StructuralPluginTest.kt
@@ -916,6 +916,478 @@ class StructuralPluginTest {
         assertThat(checkResult.output).contains("All package imports follow the specified package rules")
     }
 
+    // ===== Right arrow (-> ) direction tests =====
+
+    @Test
+    fun `structuralCheck should respect right arrow rule direction`() {
+        File(testProjectDir, "structural.yml").writeText(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+
+            rules:
+              - domain -> data
+              - domain -> ui
+            """
+        )
+
+        // data can import from domain (domain -> data means data is allowed to import domain)
+        File(testProjectDir, "src/main/kotlin/com/example/data/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.data
+
+                import com.example.domain.SomeClass
+
+                class Test
+                """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .build()
+
+        assertThat(result.output).doesNotContain("cannot import")
+    }
+
+    @Test
+    fun `structuralCheck should forbid reverse of right arrow direction`() {
+        File(testProjectDir, "structural.yml").writeText(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+
+            rules:
+              - domain -> data
+            """
+        )
+
+        // domain cannot import from data (only data can import from domain)
+        File(testProjectDir, "src/main/kotlin/com/example/domain/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.domain
+
+                import com.example.data.SomeClass
+
+                class Test
+                """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .buildAndFail()
+
+        assertThat(result.output).contains("`com.example.domain` cannot import from `com.example.data`")
+    }
+
+    // ===== Overlapping tracked packages =====
+
+    @Test
+    fun `structuralCheck should handle file matching multiple tracked package segments`() {
+        File(testProjectDir, "structural.yml").writeText(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+
+            rules:
+              - data <- domain
+              - domain <- ui
+            """
+        )
+
+        // File in data.domain — both 'data' and 'domain' are tracked
+        File(testProjectDir, "src/main/kotlin/com/example/data/domain/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.data.domain
+
+                import com.example.ui.SomeClass
+
+                class Test
+                """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .buildAndFail()
+
+        // The 'data' layer doesn't allow ui, so this should fail
+        assertThat(result.output).contains("cannot import from `com.example.ui`")
+    }
+
+    // ===== Circular / bidirectional rules =====
+
+    @Test
+    fun `structuralCheck should allow circular rules`() {
+        File(testProjectDir, "structural.yml").writeText(
+            """
+            packages:
+              - a
+              - b
+
+            rules:
+              - a <- b
+              - b <- a
+            """
+        )
+
+        File(testProjectDir, "src/main/kotlin/com/example/a/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.a
+
+                import com.example.b.SomeClass
+
+                class Test
+                """
+            )
+        }
+        File(testProjectDir, "src/main/kotlin/com/example/b/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.b
+
+                import com.example.a.SomeClass
+
+                class Test
+                """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .build()
+
+        assertThat(result.output).doesNotContain("cannot import")
+    }
+
+    // ===== Tracked package with zero rules =====
+
+    @Test
+    fun `structuralCheck should forbid all imports for tracked package with no rules`() {
+        File(testProjectDir, "structural.yml").writeText(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+
+            rules:
+              - data <- domain
+            """
+        )
+
+        // ui has no rules — it should not be able to import from any tracked package
+        File(testProjectDir, "src/main/kotlin/com/example/ui/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.ui
+
+                import com.example.data.SomeClass
+
+                class Test
+                """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .buildAndFail()
+
+        assertThat(result.output).contains("`com.example.ui` cannot import from `com.example.data`")
+    }
+
+    // ===== FileOnSameLevelAsPackages baseline integration =====
+
+    @Test
+    fun `structuralCheck should baseline FileOnSameLevelAsPackages violations`() {
+        File(testProjectDir, "src/main/kotlin/com/example/data/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                    package com.example.data
+
+                    import com.example.SameLevelClass
+
+                    class Test
+                    """
+            )
+        }
+        File(testProjectDir, "src/main/kotlin/com/example/SameLevelClass.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                    package com.example
+
+                    class SameLevelClass
+                    """
+            )
+        }
+
+        // First verify it fails without baseline
+        val failResult = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .buildAndFail()
+
+        assertThat(failResult.output).contains("is on the same level as")
+
+        // Generate baseline
+        GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralGenerateBaseline")
+            .build()
+
+        // Now check should pass
+        val passResult = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .build()
+
+        assertThat(passResult.output).contains("All package imports follow the specified package rules")
+    }
+
+    // ===== New violations after baseline =====
+
+    @Test
+    fun `structuralCheck should fail for new violations even with baseline`() {
+        File(testProjectDir, "src/main/kotlin/com/example/ui/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.ui
+
+                import com.example.data.SomeClass
+
+                class Test
+                """
+            )
+        }
+
+        // Generate baseline with existing violation
+        GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralGenerateBaseline")
+            .build()
+
+        // Add a NEW file with a new violation
+        File(testProjectDir, "src/main/kotlin/com/example/ui/NewFile.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.ui
+
+                import com.example.data.AnotherClass
+
+                class NewFile
+                """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .buildAndFail()
+
+        assertThat(result.output).contains("`com.example.ui` cannot import from `com.example.data`")
+        // Should only report the new violation, not the baselined one
+        assertThat(result.output).contains("1 import rule violation(s) detected in 1 file(s).")
+    }
+
+    // ===== Custom baseline path =====
+
+    @Test
+    fun `structuralCheck should respect custom baseline path`() {
+        File(testProjectDir, "build.gradle.kts").delete()
+        File(testProjectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("com.adrianczuczka.structural")
+            }
+            repositories {
+                mavenCentral()
+            }
+            structural {
+                baseline = "${'$'}rootDir/custom-baseline.xml"
+            }
+            """
+        )
+
+        File(testProjectDir, "src/main/kotlin/com/example/ui/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.ui
+
+                import com.example.data.SomeClass
+
+                class Test
+                """
+            )
+        }
+
+        // Generate baseline to custom path
+        GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralGenerateBaseline")
+            .build()
+
+        val customBaseline = File(testProjectDir, "custom-baseline.xml")
+        assertThat(customBaseline.exists()).isTrue()
+
+        // Check should pass with custom baseline
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .build()
+
+        assertThat(result.output).doesNotContain("cannot import")
+    }
+
+    // ===== Same package imports =====
+
+    @Test
+    fun `structuralCheck should allow imports within the same package`() {
+        File(testProjectDir, "src/main/kotlin/com/example/data/TestA.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.data
+
+                import com.example.data.TestB
+
+                class TestA
+                """
+            )
+        }
+        File(testProjectDir, "src/main/kotlin/com/example/data/TestB.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.data
+
+                class TestB
+                """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .build()
+
+        assertThat(result.output).doesNotContain("cannot import")
+    }
+
+    // ===== FileOnSameLevelAsPackages error message =====
+
+    @Test
+    fun `structuralCheck FileOnSameLevelAsPackages error message includes class name and package`() {
+        File(testProjectDir, "src/main/kotlin/com/example/data/Test.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                    package com.example.data
+
+                    import com.example.RootClass
+
+                    class Test
+                    """
+            )
+        }
+        File(testProjectDir, "src/main/kotlin/com/example/RootClass.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                    package com.example
+
+                    class RootClass
+                    """
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .buildAndFail()
+
+        assertThat(result.output).contains("class \"RootClass\" is on the same level as \"com.example\" package")
+        assertThat(result.output).contains("Move into a package")
+    }
+
+    // ===== Mixed Java and Kotlin files =====
+
+    @Test
+    fun `structuralCheck should detect violations across Java and Kotlin files`() {
+        File(testProjectDir, "src/main/kotlin/com/example/ui/KotlinFile.kt").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.ui
+
+                import com.example.data.SomeClass
+
+                class KotlinFile
+                """
+            )
+        }
+        File(testProjectDir, "src/main/java/com/example/ui/JavaFile.java").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.example.ui;
+
+                import com.example.data.SomeClass;
+
+                public class JavaFile {}
+                """.trimIndent()
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath()
+            .withArguments("structuralCheck")
+            .buildAndFail()
+
+        assertThat(result.output).contains("2 import rule violation(s) detected in 2 file(s).")
+    }
+
     @Test
     fun `structuralCheck error message should include total violation count`() {
         File(testProjectDir, "src/main/kotlin/com/example/ui/Test.kt").apply {

--- a/core/src/test/kotlin/com/adrianczuczka/structural/UtilTest.kt
+++ b/core/src/test/kotlin/com/adrianczuczka/structural/UtilTest.kt
@@ -1,0 +1,545 @@
+package com.adrianczuczka.structural
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class UtilTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeEach
+    fun setup() {
+        tempDir = createTempDirectory("util-test").toFile()
+    }
+
+    @AfterEach
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    // ===== extractPackageFromImport =====
+
+    @Nested
+    inner class ExtractPackageFromImportTest {
+
+        @Test
+        fun `extracts package from simple import`() {
+            val result = extractPackageFromImport("com.example.data.SomeClass")
+            assertThat(result).isEqualTo("com.example.data")
+        }
+
+        @Test
+        fun `extracts package from deep import`() {
+            val result = extractPackageFromImport("com.example.app.data.local.db.Entity")
+            assertThat(result).isEqualTo("com.example.app.data.local.db")
+        }
+
+        @Test
+        fun `returns import as-is when single segment`() {
+            val result = extractPackageFromImport("SomeClass")
+            assertThat(result).isEqualTo("SomeClass")
+        }
+
+        @Test
+        fun `extracts package from two-segment import`() {
+            val result = extractPackageFromImport("data.SomeClass")
+            assertThat(result).isEqualTo("data")
+        }
+
+        @Test
+        fun `handles wildcard import`() {
+            val result = extractPackageFromImport("com.example.data.*")
+            assertThat(result).isEqualTo("com.example.data")
+        }
+
+        @Test
+        fun `handles static import by dropping two segments`() {
+            val result = extractPackageFromImport("com.example.data.SomeClass.someMethod", isStatic = true)
+            assertThat(result).isEqualTo("com.example.data")
+        }
+
+        @Test
+        fun `static import with only two segments drops one`() {
+            val result = extractPackageFromImport("SomeClass.someMethod", isStatic = true)
+            assertThat(result).isEqualTo("SomeClass")
+        }
+
+        @Test
+        fun `static import with three segments drops two`() {
+            val result = extractPackageFromImport("data.SomeClass.someMethod", isStatic = true)
+            assertThat(result).isEqualTo("data")
+        }
+    }
+
+    // ===== Java file parsing =====
+
+    @Nested
+    inner class JavaParsingTest {
+
+        @Test
+        fun `parses Java file with package and imports`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    package com.example.ui;
+
+                    import com.example.data.Repository;
+                    import com.example.domain.UseCase;
+
+                    public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isEqualTo("com.example.ui")
+            assertThat(result.imports).hasSize(2)
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data.Repository")
+            assertThat(result.imports[0].className).isEqualTo("Repository")
+            assertThat(result.imports[0].isStatic).isFalse()
+            assertThat(result.imports[1].importPath).isEqualTo("com.example.domain.UseCase")
+        }
+
+        @Test
+        fun `parses Java file with no package declaration`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    import com.example.data.Repository;
+
+                    public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isNull()
+            assertThat(result.imports).hasSize(1)
+        }
+
+        @Test
+        fun `parses Java file with no imports`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    package com.example.ui;
+
+                    public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isEqualTo("com.example.ui")
+            assertThat(result.imports).isEmpty()
+        }
+
+        @Test
+        fun `parses Java static import`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    package com.example.ui;
+
+                    import static com.example.data.Constants.MAX_SIZE;
+
+                    public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.imports).hasSize(1)
+            assertThat(result.imports[0].isStatic).isTrue()
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data.Constants.MAX_SIZE")
+            assertThat(result.imports[0].className).isEqualTo("MAX_SIZE")
+        }
+
+        @Test
+        fun `parses Java wildcard import`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    package com.example.ui;
+
+                    import com.example.data.*;
+
+                    public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.imports).hasSize(1)
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data.*")
+            assertThat(result.imports[0].className).isNull()
+        }
+
+        @Test
+        fun `parses Java file with comments before package`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    // This is a comment
+                    /* Another comment */
+                    package com.example.ui;
+
+                    import com.example.data.Repository;
+
+                    public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isEqualTo("com.example.ui")
+            assertThat(result.imports).hasSize(1)
+        }
+
+        @Test
+        fun `ignores import-like text in string literals`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    package com.example.ui;
+
+                    import com.example.data.Repository;
+
+                    public class Test {
+                        String s = "import com.example.domain.Fake;";
+                    }
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            // The regex requires the line to start with optional whitespace then "import",
+            // so inline string content should not match since it has quotes before it
+            assertThat(result.imports).hasSize(1)
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data.Repository")
+        }
+
+        @Test
+        fun `records correct line numbers for Java imports`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """package com.example.ui;
+
+import com.example.data.A;
+import com.example.data.B;
+
+public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.imports[0].lineNumber).isEqualTo(3)
+            assertThat(result.imports[1].lineNumber).isEqualTo(4)
+        }
+
+        @Test
+        fun `parses empty Java file`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText("")
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isNull()
+            assertThat(result.imports).isEmpty()
+        }
+
+        @Test
+        fun `parses Java static wildcard import`() {
+            val file = File(tempDir, "Test.java").apply {
+                writeText(
+                    """
+                    package com.example.ui;
+
+                    import static com.example.data.Constants.*;
+
+                    public class Test {}
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.imports).hasSize(1)
+            assertThat(result.imports[0].isStatic).isTrue()
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data.Constants.*")
+            assertThat(result.imports[0].className).isNull()
+        }
+    }
+
+    // ===== Kotlin file parsing =====
+
+    @Nested
+    inner class KotlinParsingTest {
+
+        @Test
+        fun `parses Kotlin file with package and imports`() {
+            val file = File(tempDir, "Test.kt").apply {
+                writeText(
+                    """
+                    package com.example.ui
+
+                    import com.example.data.Repository
+                    import com.example.domain.UseCase
+
+                    class Test
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isEqualTo("com.example.ui")
+            assertThat(result.imports).hasSize(2)
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data.Repository")
+            assertThat(result.imports[1].importPath).isEqualTo("com.example.domain.UseCase")
+        }
+
+        @Test
+        fun `parses Kotlin file with no package declaration`() {
+            val file = File(tempDir, "Test.kt").apply {
+                writeText(
+                    """
+                    import com.example.data.Repository
+
+                    class Test
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isNull()
+            assertThat(result.imports).hasSize(1)
+        }
+
+        @Test
+        fun `parses Kotlin file with no imports`() {
+            val file = File(tempDir, "Test.kt").apply {
+                writeText(
+                    """
+                    package com.example.ui
+
+                    class Test
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isEqualTo("com.example.ui")
+            assertThat(result.imports).isEmpty()
+        }
+
+        @Test
+        fun `parses Kotlin wildcard import`() {
+            val file = File(tempDir, "Test.kt").apply {
+                writeText(
+                    """
+                    package com.example.ui
+
+                    import com.example.data.*
+
+                    class Test
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.imports).hasSize(1)
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data")
+        }
+
+        @Test
+        fun `parses Kotlin alias import`() {
+            val file = File(tempDir, "Test.kt").apply {
+                writeText(
+                    """
+                    package com.example.ui
+
+                    import com.example.data.Repository as Repo
+
+                    class Test
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.imports).hasSize(1)
+            assertThat(result.imports[0].importPath).isEqualTo("com.example.data.Repository")
+        }
+
+        @Test
+        fun `parses empty Kotlin file`() {
+            val file = File(tempDir, "Test.kt").apply {
+                writeText("")
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isNull()
+            assertThat(result.imports).isEmpty()
+        }
+
+        @Test
+        fun `parses Kotlin file with multiple classes`() {
+            val file = File(tempDir, "Test.kt").apply {
+                writeText(
+                    """
+                    package com.example.ui
+
+                    import com.example.data.Repository
+
+                    class TestA
+                    class TestB
+                    data class TestC(val x: Int)
+                    """.trimIndent()
+                )
+            }
+            val result = file.parseSourceFile()
+            assertThat(result.packageName).isEqualTo("com.example.ui")
+            assertThat(result.imports).hasSize(1)
+        }
+    }
+
+    // ===== getIgnoredViolationsFromBaseline =====
+
+    @Nested
+    inner class BaselineParsingTest {
+
+        @Test
+        fun `returns empty map when file does not exist`() {
+            val result = getIgnoredViolationsFromBaseline(File(tempDir, "nonexistent.xml").absolutePath)
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `parses ForbiddenImport violations from baseline`() {
+            val file = File(tempDir, "baseline.xml").apply {
+                writeText(
+                    """
+                    <?xml version="1.0" ?>
+                    <StructuralBaseline>
+                      <CurrentIssues>
+                        <ID>ForbiddenImport${'$'}TestFile${'$'}5${'$'}com.example.ui${'$'}com.example.data</ID>
+                      </CurrentIssues>
+                    </StructuralBaseline>
+                    """.trimIndent()
+                )
+            }
+            val result = getIgnoredViolationsFromBaseline(file.absolutePath)
+            assertThat(result).hasSize(1)
+            assertThat(result["TestFile"]).hasSize(1)
+            val violation = result["TestFile"]!![0] as ViolationData.ForbiddenImport
+            assertThat(violation.lineNumber).isEqualTo(5)
+            assertThat(violation.importingPackage).isEqualTo("com.example.ui")
+            assertThat(violation.importedPackage).isEqualTo("com.example.data")
+        }
+
+        @Test
+        fun `parses FileOnSameLevelAsPackages violations from baseline`() {
+            val file = File(tempDir, "baseline.xml").apply {
+                writeText(
+                    """
+                    <?xml version="1.0" ?>
+                    <StructuralBaseline>
+                      <CurrentIssues>
+                        <ID>FileOnSameLevelAsPackages${'$'}TestFile${'$'}3${'$'}SomeClass${'$'}com.example</ID>
+                      </CurrentIssues>
+                    </StructuralBaseline>
+                    """.trimIndent()
+                )
+            }
+            val result = getIgnoredViolationsFromBaseline(file.absolutePath)
+            assertThat(result).hasSize(1)
+            val violation = result["TestFile"]!![0] as ViolationData.FileOnSameLevelAsPackages
+            assertThat(violation.lineNumber).isEqualTo(3)
+            assertThat(violation.className).isEqualTo("SomeClass")
+            assertThat(violation.importedPackage).isEqualTo("com.example")
+        }
+
+        @Test
+        fun `parses multiple violations for same file`() {
+            val file = File(tempDir, "baseline.xml").apply {
+                writeText(
+                    """
+                    <?xml version="1.0" ?>
+                    <StructuralBaseline>
+                      <CurrentIssues>
+                        <ID>ForbiddenImport${'$'}TestFile${'$'}5${'$'}com.example.ui${'$'}com.example.data</ID>
+                        <ID>ForbiddenImport${'$'}TestFile${'$'}6${'$'}com.example.ui${'$'}com.example.domain</ID>
+                      </CurrentIssues>
+                    </StructuralBaseline>
+                    """.trimIndent()
+                )
+            }
+            val result = getIgnoredViolationsFromBaseline(file.absolutePath)
+            assertThat(result["TestFile"]).hasSize(2)
+        }
+
+        @Test
+        fun `parses violations across multiple files`() {
+            val file = File(tempDir, "baseline.xml").apply {
+                writeText(
+                    """
+                    <?xml version="1.0" ?>
+                    <StructuralBaseline>
+                      <CurrentIssues>
+                        <ID>ForbiddenImport${'$'}FileA${'$'}5${'$'}com.example.ui${'$'}com.example.data</ID>
+                        <ID>ForbiddenImport${'$'}FileB${'$'}3${'$'}com.example.domain${'$'}com.example.data</ID>
+                      </CurrentIssues>
+                    </StructuralBaseline>
+                    """.trimIndent()
+                )
+            }
+            val result = getIgnoredViolationsFromBaseline(file.absolutePath)
+            assertThat(result).hasSize(2)
+            assertThat(result["FileA"]).hasSize(1)
+            assertThat(result["FileB"]).hasSize(1)
+        }
+
+        @Test
+        fun `returns empty map for empty baseline`() {
+            val file = File(tempDir, "baseline.xml").apply {
+                writeText(
+                    """
+                    <?xml version="1.0" ?>
+                    <StructuralBaseline>
+                      <CurrentIssues>
+                      </CurrentIssues>
+                    </StructuralBaseline>
+                    """.trimIndent()
+                )
+            }
+            val result = getIgnoredViolationsFromBaseline(file.absolutePath)
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `skips ID entries with fewer than 5 parts`() {
+            val file = File(tempDir, "baseline.xml").apply {
+                writeText(
+                    """
+                    <?xml version="1.0" ?>
+                    <StructuralBaseline>
+                      <CurrentIssues>
+                        <ID>MalformedEntry${'$'}OnlyThree${'$'}Parts</ID>
+                        <ID>ForbiddenImport${'$'}TestFile${'$'}5${'$'}com.example.ui${'$'}com.example.data</ID>
+                      </CurrentIssues>
+                    </StructuralBaseline>
+                    """.trimIndent()
+                )
+            }
+            val result = getIgnoredViolationsFromBaseline(file.absolutePath)
+            assertThat(result).hasSize(1)
+            assertThat(result["TestFile"]).hasSize(1)
+        }
+
+        @Test
+        fun `skips unknown violation types`() {
+            val file = File(tempDir, "baseline.xml").apply {
+                writeText(
+                    """
+                    <?xml version="1.0" ?>
+                    <StructuralBaseline>
+                      <CurrentIssues>
+                        <ID>UnknownType${'$'}TestFile${'$'}5${'$'}foo${'$'}bar</ID>
+                      </CurrentIssues>
+                    </StructuralBaseline>
+                    """.trimIndent()
+                )
+            }
+            val result = getIgnoredViolationsFromBaseline(file.absolutePath)
+            assertThat(result).isEmpty()
+        }
+    }
+}

--- a/core/src/test/kotlin/com/adrianczuczka/structural/baseline/BaselineDataTest.kt
+++ b/core/src/test/kotlin/com/adrianczuczka/structural/baseline/BaselineDataTest.kt
@@ -1,0 +1,80 @@
+package com.adrianczuczka.structural.baseline
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class BaselineDataTest {
+
+    @Test
+    fun `toXml produces valid XML with violations`() {
+        val baseline = BaselineData(
+            listOf(
+                "ForbiddenImport\$TestFile\$5\$com.example.ui\$com.example.data",
+                "FileOnSameLevelAsPackages\$TestFile\$3\$SomeClass\$com.example"
+            )
+        )
+        val xml = baseline.toXml()
+        assertThat(xml).contains("<?xml version=\"1.0\" ?>")
+        assertThat(xml).contains("<StructuralBaseline>")
+        assertThat(xml).contains("<CurrentIssues>")
+        assertThat(xml).contains("<ID>ForbiddenImport\$TestFile\$5\$com.example.ui\$com.example.data</ID>")
+        assertThat(xml).contains("<ID>FileOnSameLevelAsPackages\$TestFile\$3\$SomeClass\$com.example</ID>")
+        assertThat(xml).contains("</CurrentIssues>")
+        assertThat(xml).contains("</StructuralBaseline>")
+    }
+
+    @Test
+    fun `toXml with empty violations list produces valid XML`() {
+        val baseline = BaselineData(emptyList())
+        val xml = baseline.toXml()
+        assertThat(xml).contains("<StructuralBaseline>")
+        assertThat(xml).contains("<CurrentIssues>")
+        assertThat(xml).contains("</CurrentIssues>")
+        assertThat(xml).doesNotContain("<ID>")
+    }
+
+    @Test
+    fun `toXml with single violation`() {
+        val baseline = BaselineData(
+            listOf("ForbiddenImport\$Test\$1\$com.a\$com.b")
+        )
+        val xml = baseline.toXml()
+        assertThat(xml).contains("<ID>ForbiddenImport\$Test\$1\$com.a\$com.b</ID>")
+    }
+
+    @Test
+    fun `toXml round-trips through XML parser`() {
+        val violations = listOf(
+            "ForbiddenImport\$TestFile\$5\$com.example.ui\$com.example.data",
+            "FileOnSameLevelAsPackages\$TestFile\$3\$SomeClass\$com.example"
+        )
+        val baseline = BaselineData(violations)
+        val xml = baseline.toXml()
+
+        // Parse the XML back
+        val factory = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        val document = factory.newDocumentBuilder().parse(xml.byteInputStream())
+        document.documentElement.normalize()
+
+        val idNodes = document.getElementsByTagName("ID")
+        val parsedViolations = (0 until idNodes.length).map { idNodes.item(it).textContent.trim() }
+
+        assertThat(parsedViolations).containsExactlyElementsIn(violations)
+    }
+
+    @Test
+    fun `toXml handles special characters in violation IDs`() {
+        val baseline = BaselineData(
+            listOf("ForbiddenImport\$MyFile\$10\$com.example.ui\$com.example.data.local")
+        )
+        val xml = baseline.toXml()
+        assertThat(xml).contains("ForbiddenImport\$MyFile\$10\$com.example.ui\$com.example.data.local")
+
+        // Verify it's still parseable XML
+        val factory = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        val document = factory.newDocumentBuilder().parse(xml.byteInputStream())
+        assertThat(document.getElementsByTagName("ID").length).isEqualTo(1)
+    }
+}

--- a/core/src/test/kotlin/com/adrianczuczka/structural/yaml/YamlParserTest.kt
+++ b/core/src/test/kotlin/com/adrianczuczka/structural/yaml/YamlParserTest.kt
@@ -1,0 +1,350 @@
+package com.adrianczuczka.structural.yaml
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.GradleException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class YamlParserTest {
+
+    private lateinit var tempDir: File
+
+    @BeforeEach
+    fun setup() {
+        tempDir = createTempDirectory("yaml-parser-test").toFile()
+    }
+
+    @AfterEach
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    private fun yamlFile(content: String): File =
+        File(tempDir, "structural.yml").apply { writeText(content) }
+
+    // --- Non-existent file ---
+
+    @Test
+    fun `returns null when file does not exist`() {
+        val result = File(tempDir, "nonexistent.yml").parseYamlImportRules()
+        assertThat(result).isNull()
+    }
+
+    // --- Arrow syntax ---
+
+    @Test
+    fun `parses left arrow rule correctly`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules:
+              - data <- domain
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.checkedPackages).containsExactly("data", "domain")
+        assertThat(result.rules["data"]).containsExactly("domain")
+        assertThat(result.rules["domain"]).isEmpty()
+    }
+
+    @Test
+    fun `parses right arrow rule correctly`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules:
+              - domain -> data
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["data"]).containsExactly("domain")
+        assertThat(result.rules["domain"]).isEmpty()
+    }
+
+    @Test
+    fun `parses chained arrows correctly`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+            rules:
+              - data <- domain -> ui
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["data"]).containsExactly("domain")
+        assertThat(result.rules["ui"]).containsExactly("domain")
+    }
+
+    @Test
+    fun `parses long chain of arrows`() {
+        val file = yamlFile(
+            """
+            packages:
+              - a
+              - b
+              - c
+              - d
+            rules:
+              - a <- b <- c <- d
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["a"]).containsExactly("b")
+        assertThat(result.rules["b"]).containsExactly("c")
+        assertThat(result.rules["c"]).containsExactly("d")
+    }
+
+    @Test
+    fun `parses mixed arrow directions in chain`() {
+        val file = yamlFile(
+            """
+            packages:
+              - a
+              - b
+              - c
+            rules:
+              - a -> b <- c
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        // a -> b means b can import from a
+        assertThat(result.rules["b"]).containsExactly("a", "c")
+    }
+
+    @Test
+    fun `multiple arrow rules accumulate allowed imports`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+            rules:
+              - data <- domain
+              - data <- ui
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["data"]).containsExactly("domain", "ui")
+    }
+
+    // --- Map syntax ---
+
+    @Test
+    fun `parses map-based rules`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+            rules:
+              data:
+                - domain
+                - ui
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["data"]).containsExactly("domain", "ui")
+        assertThat(result.rules["domain"]).isEmpty()
+        assertThat(result.rules["ui"]).isEmpty()
+    }
+
+    @Test
+    fun `map syntax with single allowed import`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules:
+              data:
+                - domain
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["data"]).containsExactly("domain")
+    }
+
+    // --- Empty / missing rules ---
+
+    @Test
+    fun `empty rules list produces no allowed imports`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules: []
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["data"]).isEmpty()
+        assertThat(result.rules["domain"]).isEmpty()
+    }
+
+    @Test
+    fun `throws when rules key is missing`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            """.trimIndent()
+        )
+        val exception = assertThrows<GradleException> { file.parseYamlImportRules() }
+        assertThat(exception.message).contains("No rules specified")
+    }
+
+    @Test
+    fun `throws when packages list is missing`() {
+        val file = yamlFile(
+            """
+            rules:
+              - data <- domain
+            """.trimIndent()
+        )
+        val exception = assertThrows<GradleException> { file.parseYamlImportRules() }
+        assertThat(exception.message).contains("No packages specified")
+    }
+
+    @Test
+    fun `throws when packages list is empty`() {
+        val file = yamlFile(
+            """
+            packages: []
+            rules:
+              - data <- domain
+            """.trimIndent()
+        )
+        val exception = assertThrows<GradleException> { file.parseYamlImportRules() }
+        assertThat(exception.message).contains("No packages specified")
+    }
+
+    @Test
+    fun `throws when rules is a string`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules: "some string"
+            """.trimIndent()
+        )
+        val exception = assertThrows<GradleException> { file.parseYamlImportRules() }
+        assertThat(exception.message).contains("Invalid rules format")
+    }
+
+    @Test
+    fun `throws when arrow rule has no arrow`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules:
+              - data domain
+            """.trimIndent()
+        )
+        val exception = assertThrows<GradleException> { file.parseYamlImportRules() }
+        assertThat(exception.message).contains("Invalid rule format")
+    }
+
+    @Test
+    fun `throws when arrow rule has blank parts`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules:
+              - "<- domain"
+            """.trimIndent()
+        )
+        val exception = assertThrows<GradleException> { file.parseYamlImportRules() }
+        assertThat(exception.message).contains("Invalid rule format")
+    }
+
+    // --- Packages with extra whitespace ---
+
+    @Test
+    fun `handles whitespace around arrow parts`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+            rules:
+              - "data   <-   domain"
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["data"]).containsExactly("domain")
+    }
+
+    // --- Tracked package with zero rules ---
+
+    @Test
+    fun `tracked package with no rules gets empty allowed list`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - domain
+              - ui
+            rules:
+              - data <- domain
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["ui"]).isEmpty()
+    }
+
+    // --- Duplicate packages ---
+
+    @Test
+    fun `duplicate packages in list are preserved`() {
+        val file = yamlFile(
+            """
+            packages:
+              - data
+              - data
+              - domain
+            rules:
+              - data <- domain
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.checkedPackages).containsExactly("data", "data", "domain")
+    }
+
+    // --- Bidirectional rules ---
+
+    @Test
+    fun `bidirectional rules with separate lines`() {
+        val file = yamlFile(
+            """
+            packages:
+              - a
+              - b
+            rules:
+              - a <- b
+              - b <- a
+            """.trimIndent()
+        )
+        val result = file.parseYamlImportRules()!!
+        assertThat(result.rules["a"]).containsExactly("b")
+        assertThat(result.rules["b"]).containsExactly("a")
+    }
+}


### PR DESCRIPTION
- Add YamlParserTest: 20 unit tests covering arrow/map syntax, error handling,
  chained arrows, whitespace, edge cases
- Add UtilTest: 22 unit tests for extractPackageFromImport, Java/Kotlin file
  parsing, and baseline XML parsing
- Add BaselineDataTest: 5 unit tests for XML serialization and round-trip
- Add 11 new integration tests to StructuralPluginTest:
  - Right arrow (->) rule direction
  - Overlapping tracked packages
  - Circular/bidirectional rules
  - Tracked package with zero rules
  - FileOnSameLevelAsPackages baseline integration
  - New violations after baseline generation
  - Custom baseline path
  - Same-package imports
  - FileOnSameLevelAsPackages error message content
  - Mixed Java/Kotlin violation detection
- Add kotlin-compiler-embeddable testImplementation dependency for unit tests

https://claude.ai/code/session_01AgNYg58SKYjeL3A8EzbiUi